### PR TITLE
ПР по фиксу бага с созданием кешлесс транзакций пример на скрине

### DIFF
--- a/src/web.api/modules/applications-from-remonline-transactions.mjs
+++ b/src/web.api/modules/applications-from-remonline-transactions.mjs
@@ -48,7 +48,12 @@ export async function createCRMApplicationsFromRemonlineTransaction() {
           description,
           created_at,
         } = transaction;
-
+        if (value > 99_999_999.99 || value < -99_999_999.99) {
+          console.error(
+            `the value:${value} is out of float[numeric(10,2)] range which is [-99_999_999.99; 99_999_999.99]`
+          );
+          continue;
+        }
         const toBeSkipped = /^\*\*\*/.test(description.replaceAll(' ', ''));
 
         if (toBeSkipped) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69e61f21-876c-4bca-8efa-20b395a9be83)

Единственное нумерическое поле, которое используется при создании этих транзакций - sum. 
sum - представлена в постгре как float [numeric(10,2)], его рейндж это [-99_999_999.99; 99_999_999.99]
![image](https://github.com/user-attachments/assets/127cc7d1-4013-4c5d-82de-bf67a61ed6c3)

фикс : пропуск транзакции с еррор логом